### PR TITLE
fix error with package.xml containing <export>

### DIFF
--- a/ament_package/__init__.py
+++ b/ament_package/__init__.py
@@ -211,7 +211,7 @@ def parse_package_string(data, filename=None):
         for node in [n for n in export_node.childNodes
                      if n.nodeType == n.ELEMENT_NODE]:
             export = Export(str(node.tagName),
-                            _get_node_value(node, allow_xml=True))
+                            content=_get_node_value(node, allow_xml=True))
             for key, value in node.attributes.items():
                 export.attributes[str(key)] = str(value)
             exports.append(export)


### PR DESCRIPTION
I was getting this:

```
Traceback (most recent call last):
  File "/usr/local/bin/ament", line 9, in <module>
    load_entry_point('ament-tools==0.0.0', 'console_scripts', 'ament')()
  File "/Users/william/devel/ament_tools/ament_tools/commands/ament.py", line 47, in main
    sysargs,
  File "/Users/william/devel/osrf_pycommon/osrf_pycommon/cli_utils/verb_pattern.py", line 48, in create_subparsers
    sysargs,
  File "/Users/william/devel/osrf_pycommon/osrf_pycommon/cli_utils/verb_pattern.py", line 25, in call_prepare_arguments
    return func(*func_args) or parser
  File "/Users/william/devel/ament_tools/ament_tools/verbs/build_pkg/cli.py", line 77, in prepare_arguments
    build_type = get_build_type(opts.path)
  File "/Users/william/devel/ament_tools/ament_tools/verbs/build_pkg/cli.py", line 116, in get_build_type
    package = parse_package(path)
  File "/Users/william/devel/ament_package/ament_package/__init__.py", line 60, in parse_package
    return parse_package_string(f.read(), filename)
  File "/Users/william/devel/ament_package/ament_package/__init__.py", line 216, in parse_package_string
    tmp)
  File "/Users/william/devel/ament_package/ament_package/export.py", line 22, in __init__
    self.attributes = dict(attributes) if attributes else {}
ValueError: dictionary update sequence element #0 has length 1; 2 is required
```

With this `package.xml`:

``` xml
<?xml version="1.0"?>
<package format="2">
  <name>ament_cmake</name>
  <version>0.0.0</version>
  <description>The CMake config file for the ament buildsystem.</description>
  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
  <license>Apache License 2.0</license>

  <buildtool_depend>cmake</buildtool_depend>

  <buildtool_export_depend>cmake</buildtool_export_depend>

  <build_depend>ament_cmake_symlink_install</build_depend>

  <build_export_depend>ament_cmake_core</build_export_depend>
  <build_export_depend>ament_cmake_environment</build_export_depend>
  <build_export_depend>ament_cmake_environment_hooks</build_export_depend>
  <build_export_depend>ament_cmake_export_definitions</build_export_depend>
  <build_export_depend>ament_cmake_export_dependencies</build_export_depend>
  <build_export_depend>ament_cmake_export_include_directories</build_export_depend>
  <build_export_depend>ament_cmake_export_interfaces</build_export_depend>
  <build_export_depend>ament_cmake_export_libraries</build_export_depend>
  <build_export_depend>ament_cmake_gmock</build_export_depend>
  <build_export_depend>ament_cmake_gtest</build_export_depend>
  <build_export_depend>ament_cmake_index</build_export_depend>
  <build_export_depend>ament_cmake_nose</build_export_depend>
  <build_export_depend>ament_cmake_python</build_export_depend>
  <build_export_depend>ament_cmake_symlink_install</build_export_depend>
  <build_export_depend>ament_cmake_test</build_export_depend>

  <export><build_type>something_else</build_type></export>

</package>

```
