### PR TITLE
Windows Support

### DIFF
--- a/ament_package/template/environment_hook/pythonpath.bat.in
+++ b/ament_package/template/environment_hook/pythonpath.bat.in
@@ -1,0 +1,34 @@
+:: generated from ament_package/template/environment_hook/pythonpath.bat.in
+if defined AMENT_TRACE_SETUP_FILES echo Inside %~0
+
+call:ament_prepend_unique_value PYTHONPATH "%AMENT_CURRENT_PREFIX%\@PYTHON_INSTALL_DIR@"
+
+if defined AMENT_TRACE_SETUP_FILES set PYTHONPATH
+if defined AMENT_TRACE_SETUP_FILES echo Leaving %~0
+goto:eof
+
+:: function to prepend non-duplicate values to environment variables
+:: using colons as separators and avoiding trailing separators
+:ament_prepend_unique_value
+  setlocal enabledelayedexpansion
+  :: arguments
+  set "_listname=%~1"
+  set "_value=%~2"
+  :: expand the list variable
+  set "_list=!%_listname%!"
+  :: check if the list contains the value
+  set "_is_duplicate="
+  if "%_list%" NEQ "" (
+    for %%a in ("%_list:;=";"%") do (
+      if "%%a" == "%_value%" set "_is_duplicate=1"
+    )
+  )
+  :: if it is not a duplicate prepend it
+  if "%_is_duplicate%" == "" (
+    :: produces a trailing semicolon when the list empty, but that's ok
+    set "_list=%_value%;%_list%"
+  )
+  (endlocal
+    set "%~1=%_list%"
+  )
+goto:eof

--- a/ament_package/template/environment_hook/pythonpath.bat.in
+++ b/ament_package/template/environment_hook/pythonpath.bat.in
@@ -20,7 +20,7 @@ goto:eof
   set "_is_duplicate="
   if "%_list%" NEQ "" (
     for %%a in ("%_list:;=";"%") do (
-      if "%%a" == "%_value%" set "_is_duplicate=1"
+      if "%%~a" == "%_value%" set "_is_duplicate=1"
     )
   )
   :: if it is not a duplicate prepend it

--- a/ament_package/template/isolated_prefix_level/local_setup.bat.in
+++ b/ament_package/template/isolated_prefix_level/local_setup.bat.in
@@ -1,0 +1,53 @@
+:: generated from ament_package/template/isolated_prefix_level/local_setup.sh.in
+if defined AMENT_TRACE_SETUP_FILES echo Inside "%~p0"
+
+:: since this file is sourced use either the provided AMENT_CURRENT_PREFIX
+:: or fall back to the destination set at configure time
+if not defined AMENT_CURRENT_PREFIX (
+  set "AMENT_CURRENT_PREFIX=@CMAKE_INSTALL_PREFIX@"
+)
+
+:: set type of shell if not already set
+if not defined AMENT_SHELL (
+  set "AMENT_SHELL=bat"
+)
+
+:: get all packages in topological order
+set "_ORDERED_PACKAGES="
+:ament_get_ordered_packages _ORDERED_PACKAGES "%AMENT_CURRENT_PREFIX%"
+
+:: source prefix-level local_setup.EXT or local_setup.sh file for each package
+:: store AMENT_CURRENT_PREFIX to restore it before each package
+set "_isolated_prefix_local_setup_AMENT_CURRENT_PREFIX=%AMENT_CURRENT_PREFIX%"
+for %%a in ("%_ORDERED_PACKAGES:;=";"%") do (
+  :: restore AMENT_CURRENT_PREFIX for each prefix-level local_setup file
+  set "AMENT_CURRENT_PREFIX=%_isolated_prefix_local_setup_AMENT_CURRENT_PREFIX%\%%a"
+  :: bypass prefix-level local_setup file for performance reasons
+  set "_path=%AMENT_CURRENT_PREFIX%/share/%_package%/local_setup.bat"
+  :: trace output
+  if "%AMENT_TRACE_SETUP_FILES%" NEQ "" echo (call "%_path%")
+  if exist "%_path%" call "%_path%"
+  set "_path="
+)
+set "_ORDERED_PACKAGES="
+set "_isolated_prefix_local_setup_AMENT_CURRENT_PREFIX="
+set "AMENT_CURRENT_PREFIX="
+
+:: run any command and arugments passed
+%*
+if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
+
+:: prevent double evaluation of function below
+if defined AMENT_TRACE_SETUP_FILES echo Leaving %~0
+goto:eof
+
+:: function to get the packages in this space in topological order
+:: packages are seperated by a semicolon delimiter.
+:ament_get_ordered_packages
+  setlocal enabledelayedexpansion
+  set "ordered_packages="
+  for /f %%a in ('"@PYTHON_EXECUTABLE@" "%AMENT_CURRENT_PREFIX%\_order_isolated_packages.py" "%AMENT_CURRENT_PREFIX%"') do (
+    if "%ordered_packages%" NEQ "" set "ordered_packages=%ordered_packages%;"
+    set "ordered_packages=%ordered_packages%%%a"
+  )
+goto:eof

--- a/ament_package/template/package_level/local_setup.bat.in
+++ b/ament_package/template/package_level/local_setup.bat.in
@@ -1,0 +1,78 @@
+:: generated from ament_package/template/package_level/local_setup.bat.in
+if defined AMENT_TRACE_SETUP_FILES echo Inside %~0
+
+:: since this file is called use either the provided AMENT_CURRENT_PREFIX
+:: or fall back to the destination set at configure time
+if not defined AMENT_CURRENT_PREFIX (
+  set "AMENT_CURRENT_PREFIX=@CMAKE_INSTALL_PREFIX@"
+)
+
+:: unset AMENT_ENVIRONMENT_HOOKS
+:: if not appending to them for return
+if "%AMENT_RETURN_ENVIRONMENT_HOOKS%" == "" (
+    set "AMENT_ENVIRONMENT_HOOKS="
+)
+
+:: this is a list all environment hooks of this package
+@ENVIRONMENT_HOOKS_BAT@
+
+:: source all shell-specific environment hooks of this package
+:: if not returning them
+if "%AMENT_RETURN_ENVIRONMENT_HOOKS%" == "" (
+  for %%a in ("%AMENT_ENVIRONMENT_HOOKS:;=";"%") do (
+    if exist "%%a" call "%%a"
+  )
+)
+
+:: reset AMENT_CURRENT_PREFIX after each package
+:: allowing to source multiple package-level setup files
+set "AMENT_CURRENT_PREFIX="
+
+:: run any command and arugments passed
+%*
+if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
+
+:: prevent second eval of functions below
+if defined AMENT_TRACE_SETUP_FILES echo Leaving %~0
+goto:eof
+
+:: function to append values to environment variables
+:: using semi-colons as separators and avoiding trailing separators
+:ament_append_value
+  setlocal enabledelayedexpansion
+  :: arguments (%~1 and %~2 are the first and second arguments)
+  set "_listname=%~1"
+  set "_value=%~2"
+  :: expand the first argument
+  set "_list=!%_listname%!"
+  :: if not empty, append a semi-colon
+  if "%_list%" NEQ "" set "_list=%_list%;"
+  :: concatenate new value
+  set "_list=%_list%%_value%"
+  :: return by reference (%~1 is the first argument)
+  (endlocal
+    set "%~1=%_list%"
+  )
+goto:eof
+
+:: function to prepend non-duplicate values to environment variables
+:: using colons as separators and avoiding trailing separators
+:ament_prepend_unique_value
+  setlocal enabledelayedexpansion
+  :: arguments
+  set "_listname=%~1"
+  set "_value=%~2"
+  :: expand the list variable
+  set "_list=!%_listname%!"
+  :: check if the list contains the value
+  set "_is_duplicate="
+  for %%a in ("%_list:;=";"%") do (
+    if "%%a" == "%_value%" set "_is_duplicate=1"
+  )
+  :: if it is not a duplicate prepend it
+  if "%_is_duplicate%" == "" (
+    if "%_list%" NEQ "" set ";%_list%"
+    set "_list=%_value%%_list%"
+  )
+goto:eof
+

--- a/ament_package/template/package_level/local_setup.bat.in
+++ b/ament_package/template/package_level/local_setup.bat.in
@@ -5,21 +5,23 @@ if defined AMENT_TRACE_SETUP_FILES echo Inside %~0
 :: or fall back to the destination set at configure time
 if not defined AMENT_CURRENT_PREFIX (
   set "AMENT_CURRENT_PREFIX=@CMAKE_INSTALL_PREFIX@"
+  call:convert_forwardslash_to_backslash AMENT_CURRENT_PREFIX
 )
 
 :: unset AMENT_ENVIRONMENT_HOOKS
 :: if not appending to them for return
-if "%AMENT_RETURN_ENVIRONMENT_HOOKS%" == "" (
-    set "AMENT_ENVIRONMENT_HOOKS="
+if not defined AMENT_RETURN_ENVIRONMENT_HOOKS (
+    set "AMENT_ENVIRONMENT_HOOKS[@PROJECT_NAME@]="
 )
 
 :: this is a list all environment hooks of this package
-@ENVIRONMENT_HOOKS_BAT@
+@ENVIRONMENT_HOOKS@
 
 :: source all shell-specific environment hooks of this package
 :: if not returning them
-if "%AMENT_RETURN_ENVIRONMENT_HOOKS%" == "" (
-  for %%a in ("%AMENT_ENVIRONMENT_HOOKS:;=";"%") do (
+if not defined AMENT_RETURN_ENVIRONMENT_HOOKS (
+  for %%a in ("%AMENT_ENVIRONMENT_HOOKS[@PROJECT_NAME@]:;=";"%") do (
+    echo %%~a
     if exist "%%a" call "%%a"
   )
 )
@@ -34,6 +36,17 @@ if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
 
 :: prevent second eval of functions below
 if defined AMENT_TRACE_SETUP_FILES echo Leaving %~0
+goto:eof
+
+:: converts any forwardslashes / to backslashes \ in the given variable
+:convert_forwardslash_to_backslash
+  setlocal enabledelayedexpansion
+  set "ret=%~1"
+  set "ret=!%ret%!"
+  set "ret=%ret:/=\%"
+  (endlocal
+    set "%~1=%ret%"
+  )
 goto:eof
 
 :: function to append values to environment variables
@@ -54,25 +67,3 @@ goto:eof
     set "%~1=%_list%"
   )
 goto:eof
-
-:: function to prepend non-duplicate values to environment variables
-:: using colons as separators and avoiding trailing separators
-:ament_prepend_unique_value
-  setlocal enabledelayedexpansion
-  :: arguments
-  set "_listname=%~1"
-  set "_value=%~2"
-  :: expand the list variable
-  set "_list=!%_listname%!"
-  :: check if the list contains the value
-  set "_is_duplicate="
-  for %%a in ("%_list:;=";"%") do (
-    if "%%a" == "%_value%" set "_is_duplicate=1"
-  )
-  :: if it is not a duplicate prepend it
-  if "%_is_duplicate%" == "" (
-    if "%_list%" NEQ "" set ";%_list%"
-    set "_list=%_value%%_list%"
-  )
-goto:eof
-

--- a/ament_package/template/package_level/local_setup.bat.in
+++ b/ament_package/template/package_level/local_setup.bat.in
@@ -21,7 +21,6 @@ if not defined AMENT_RETURN_ENVIRONMENT_HOOKS (
 :: if not returning them
 if not defined AMENT_RETURN_ENVIRONMENT_HOOKS (
   for %%a in ("%AMENT_ENVIRONMENT_HOOKS[@PROJECT_NAME@]:;=";"%") do (
-    echo %%~a
     if exist "%%a" call "%%a"
   )
 )

--- a/ament_package/template/prefix_level/local_setup.bat.in
+++ b/ament_package/template/prefix_level/local_setup.bat.in
@@ -17,6 +17,7 @@ if not defined AMENT_SHELL (
 
 :: find all packages under the current prefix based on the resource index
 set "_PACKAGES="
+set "AMENT_CUR_ENV_HOOKS="
 call:list_files _PACKAGES "%AMENT_CURRENT_PREFIX%\share\ament_index\resource_index\packages"
 
 :: source local_setup.bat files for each package to collect environment hooks
@@ -25,6 +26,7 @@ call:call_local_setups _PACKAGES
 :: no call the environment hooks in order
 call:call_ament_environment_hooks
 call:clear_ament_environment_hook_vars
+set "AMENT_CUR_ENV_HOOKS="
 set "_PACKAGES="
 
 :: run any command and arugments passed
@@ -56,7 +58,7 @@ goto:eof
   :: TODO(wjwwood): do a stable sort by filename, not dirname
   for /f "tokens=2 delims==" %%f in ('set AMENT_ENVIRONMENT_HOOKS[') do (
     endlocal
-    set "AMENT_CUR_ENV_HOOKS=!%%f!"
+    set "AMENT_CUR_ENV_HOOKS=%%f"
     call:call_hook
   )
 goto:eof

--- a/ament_package/template/prefix_level/local_setup.bat.in
+++ b/ament_package/template/prefix_level/local_setup.bat.in
@@ -1,0 +1,157 @@
+:: generated from ament_package/template/prefix_level/local_setup.bat.in
+@echo off
+if defined AMENT_TRACE_SETUP_FILES echo Inside "%~0"
+
+:: since this file is sourced use either the provided AMENT_CURRENT_PREFIX
+:: or fall back to the destination set at configure time
+set "AMENT_CURRENT_PREFIX="
+if not defined AMENT_CURRENT_PREFIX (
+  set "AMENT_CURRENT_PREFIX=@CMAKE_INSTALL_PREFIX@"
+  call:convert_forwardslash_to_backslash AMENT_CURRENT_PREFIX
+)
+
+:: set type of shell if not already set
+if not defined AMENT_SHELL (
+  set "AMENT_SHELL=bat"
+)
+
+:: find all packages under the current prefix based on the resource index
+set "_PACKAGES="
+call:list_files _PACKAGES "%AMENT_CURRENT_PREFIX%\share\ament_index\resource_index\packages"
+
+:: source local_setup.bat files for each package to collect environment hooks
+call:call_local_setups _PACKAGES
+
+:: no call the environment hooks in order
+call:call_ament_environment_hooks
+call:clear_ament_environment_hook_vars
+set "_PACKAGES="
+
+:: run any command and arugments passed
+%*
+if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
+
+:: prevent double evaluation of functions below
+if defined AMENT_TRACE_SETUP_FILES echo Leaving %~0
+goto:eof
+
+:foo
+  echo %~1
+goto:eof
+
+:: clears all the AMENT_ENVIRONMENT_HOOKS varaibles
+:clear_ament_environment_hook_vars
+  for /f "tokens=1 delims==" %%f in ('set AMENT_ENVIRONMENT_HOOKS[') do (
+    endlocal
+    set "%%f="
+  )
+goto:eof
+
+:: iterates through the environment hooks and sources them
+:call_ament_environment_hooks
+  setlocal enabledelayedexpansion
+  :: store AMENT_CURRENT_PREFIX to restore it before each package
+  set "_prefix_local_setup_AMENT_CURRENT_PREFIX=%AMENT_CURRENT_PREFIX%"
+  :: source each environment hook
+  :: TODO(wjwwood): do a stable sort by filename, not dirname
+  for /f "tokens=2 delims==" %%f in ('set AMENT_ENVIRONMENT_HOOKS[') do (
+    endlocal
+    set "AMENT_CUR_ENV_HOOKS=!%%f!"
+    call:call_hook
+  )
+goto:eof
+
+:call_hook
+  setlocal enabledelayedexpansion
+  for %%f in ("%AMENT_CUR_ENV_HOOKS:;=";"%") do (
+    endlocal
+    if exist %%f (
+      call %%f
+    )
+  )
+goto:eof
+
+:: iterates through a list of packages and sources the local_setup of each
+:: inorder to get a list of the AMENT_ENVIRONMENT_HOOKS
+:call_local_setups
+  setlocal enabledelayedexpansion
+  set "_package_list_name=%~1"
+  set "_PACKAGES=!%_package_list_name%!"
+  :: store AMENT_CURRENT_PREFIX to restore it before each package
+  set "_prefix_local_setup_AMENT_CURRENT_PREFIX=%AMENT_CURRENT_PREFIX%"
+  :: set the flag for sourced package-level local_setup files to
+  :: skip sourcing the environment hooks and append their environment hooks
+  set "AMENT_RETURN_ENVIRONMENT_HOOKS=1"
+  :: clear any hooks currently set
+  set "AMENT_ENVIRONMENT_HOOKS="
+  :: for each package, source the local_setup file if it exists
+  :: it should only append to the AMENT_ENVIRONMENT_HOOKS since the
+  :: AMENT_RETURN_ENVIRONMENT_HOOKS flag is set.
+  if "%_PACKAGES%" NEQ "" (
+    for %%a in ("%_PACKAGES:;=";"%") do (
+      if defined AMENT_TRACE_SETUP_FILES (
+        echo Getting env hooks for package "%%~a"
+      )
+      :: restore AMENT_CURRENT_PREFIX for each package-level local_setup file
+      set "AMENT_CURRENT_PREFIX=%_prefix_local_setup_AMENT_CURRENT_PREFIX%"
+      set "_path=%AMENT_CURRENT_PREFIX%\share\%%~a\local_setup.%AMENT_SHELL%"
+      :: trace output
+      if defined AMENT_TRACE_SETUP_FILES echo . "!_path!"
+      :: call if it exists
+      if exist "!_path!" call "!_path!"
+    )
+  )
+  :: export all of the new variables
+  for /f "tokens=1,2 delims==" %%f in ('set AMENT_ENVIRONMENT_HOOKS[') do (
+    endlocal
+    set "%%f=%%g"
+  )
+goto:eof
+
+:: converts any forwardslashes / to backslashes \ in the given variable
+:convert_forwardslash_to_backslash
+  setlocal enabledelayedexpansion
+  set "ret=%~1"
+  set "ret=!%ret%!"
+  set "ret=%ret:/=\%"
+  (endlocal
+    set "%~1=%ret%"
+  )
+goto:eof
+
+:: function to list the files in a directory in alphabetical order
+:: use list_files_sorted if you need numerical ordering
+:list_files
+  setlocal enabledelayedexpansion
+  :: create an array with filenames in right order
+  set "_files="
+  for /f %%f in ('dir /b "%~2"') do (
+    if "!_files!" NEQ "" (set "_files=!_files!;")
+    set "_files=!_files!%%~f"
+  )
+  :: return result by reference
+  (endlocal
+    set "%~1=%_files%")
+goto:eof
+
+:: function to list the files in a directory in numerical order
+:: http://stackoverflow.com/a/18749126
+:list_files_sorted
+  setlocal enabledelayedexpansion
+  :: create an array with filenames in right order
+  for /f %%f in ('dir /b "%~2"') do (
+     for /F "delims=-" %%n in ("%%f") do (
+        set "number=00000%%n"
+        set "file[!number:~-6!]=%%f"
+     )
+  )
+  :: process the filenames in right order
+  set "_files="
+  for /F "tokens=2 delims==" %%f in ('set file[') do (
+    if "%_files%" NEQ "" set "_files=%_files%;"
+    set "_files=%_files%%f%"
+  )
+  :: return result by reference
+  (endlocal
+    set "%~1=%_files%")
+goto:eof

--- a/ament_package/template/prefix_level/setup.bat.in
+++ b/ament_package/template/prefix_level/setup.bat.in
@@ -1,0 +1,128 @@
+# generated from ament_package/template/prefix_level/setup.sh.in
+
+# since this file is sourced use either the provided AMENT_CURRENT_PREFIX
+# or fall back to the destination set at configure time
+: ${AMENT_CURRENT_PREFIX:=@CMAKE_INSTALL_PREFIX@}
+
+# set type of shell if not already set
+: ${AMENT_SHELL:=sh}
+
+# find parent prefix path files for all packages under the current prefix
+_RESOURCES="$(\find "$AMENT_CURRENT_PREFIX/share/ament_parent_prefix_path" -mindepth 1 -maxdepth 1 2> /dev/null | \sort)"
+
+# function to append non-duplicate values to environment variables
+# using colons as separators and avoiding leading separators
+ament_append_unique_value() {
+  # arguments
+  _listname=$1
+  _value=$2
+  #echo "listname $_listname"
+  #eval echo "list value \$$_listname"
+  #echo "value $_value"
+
+  # check if the list contains the value
+  eval _values=\$$_listname
+  _duplicate=
+  _ament_append_unique_value_IFS=$IFS
+  IFS=":"
+  if [ "$AMENT_SHELL" = "zsh" ]; then
+    ament_zsh_to_array _values
+  fi
+  for _item in $_values; do
+    # ignore empty strings
+    if [ -z "$_item" ]; then
+      continue
+    fi
+    if [ $_item = $_value ]; then
+      _duplicate=1
+    fi
+  done
+  unset _item
+
+  # append only non-duplicates
+  if [ -z "$_duplicate" ]; then
+    # avoid leading separator
+    if [ -z "$_values" ]; then
+      eval $_listname=$_value
+      #eval echo "set list \$$_listname"
+    else
+      # field separator must not be a colon
+      unset IFS
+      eval $_listname=\$$_listname:$_value
+      #eval echo "append list \$$_listname"
+    fi
+  fi
+  IFS=$_ament_append_unique_value_IFS
+  unset _ament_append_unique_value_IFS
+  unset _duplicate
+  unset _values
+
+  unset _value
+  unset _listname
+}
+
+# iterate over all ament_parent_prefix_path files
+_prefix_setup_IFS=$IFS
+IFS="
+"
+# this variable contains the concatenated prefix paths in reverse order
+_UNIQUE_PREFIX_PATH=""
+if [ "$AMENT_SHELL" = "zsh" ]; then
+  ament_zsh_to_array _RESOURCES
+fi
+for _resource in $_RESOURCES; do
+  # read the content of the ament_parent_prefix_path file
+  _PARENT_PREFIX_PATH="$(\cat "$_resource")"
+  # reverse the list
+  _REVERSED_PARENT_PREFIX_PATH=""
+  IFS=":"
+  if [ "$AMENT_SHELL" = "zsh" ]; then
+    ament_zsh_to_array _PARENT_PREFIX_PATH
+  fi
+  for _path in $_PARENT_PREFIX_PATH; do
+    # avoid leading separator
+    if [ -z "$_REVERSED_PARENT_PREFIX_PATH" ]; then
+      _REVERSED_PARENT_PREFIX_PATH=$_path
+    else
+      _REVERSED_PARENT_PREFIX_PATH=$_REVERSED_PARENT_PREFIX_PATH:\$$_path
+    fi
+  done
+  unset _PARENT_PREFIX_PATH
+  # collect all unique parent prefix path
+  if [ "$AMENT_SHELL" = "zsh" ]; then
+    ament_zsh_to_array _REVERSED_PARENT_PREFIX_PATH
+  fi
+  for _path in $_REVERSED_PARENT_PREFIX_PATH; do
+    ament_append_unique_value _UNIQUE_PREFIX_PATH "$_path"
+  done
+  unset _REVERSED_PARENT_PREFIX_PATH
+done
+unset _resource
+unset _RESOURCES
+
+# append this directory to the prefix path
+ament_append_unique_value _UNIQUE_PREFIX_PATH "$AMENT_CURRENT_PREFIX"
+unset AMENT_CURRENT_PREFIX
+
+# source local_setup.EXT or local_setup.sh file for each prefix path
+IFS=":"
+if [ "$AMENT_SHELL" = "zsh" ]; then
+  ament_zsh_to_array _UNIQUE_PREFIX_PATH
+fi
+for _path in $_UNIQUE_PREFIX_PATH; do
+  # trace output
+  if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+    echo ". \"$_path/local_setup.$AMENT_SHELL\""
+  fi
+  if [ -f "$_path/local_setup.$AMENT_SHELL" ]; then
+    if [ "$AMENT_SHELL" = "sh" ]; then
+      # provide AMENT_CURRENT_PREFIX to .sh files
+      AMENT_CURRENT_PREFIX=$_path
+    fi
+    . "$_path/local_setup.$AMENT_SHELL"
+  fi
+done
+unset _path
+IFS=$_prefix_setup_IFS
+unset _prefix_setup_IFS
+unset _UNIQUE_PREFIX_PATH

--- a/ament_package/templates.py
+++ b/ament_package/templates.py
@@ -23,7 +23,12 @@ def get_environment_hook_template_path(name):
 
 
 def get_package_level_template_names():
-    return ['local_setup.%s.in' % ext for ext in ['bash', 'sh', 'zsh', 'bat']]
+    return ['local_setup.%s.in' % ext for ext in [
+        'bash',
+        'bat',
+        'sh',
+        'zsh',
+    ]]
 
 
 def get_package_level_template_path(name):
@@ -31,7 +36,12 @@ def get_package_level_template_path(name):
 
 
 def get_prefix_level_template_names():
-    extensions = ['bash', 'sh.in', 'zsh', 'bat.in']
+    extensions = [
+        'bash',
+        'bat.in',
+        'sh.in',
+        'zsh',
+    ]
     return ['local_setup.%s' % ext for ext in extensions] + \
         ['setup.%s' % ext for ext in extensions]
 
@@ -41,10 +51,15 @@ def get_prefix_level_template_path(name):
 
 
 def get_isolated_prefix_level_template_names():
-    extensions = ['bash', 'sh.in', 'zsh', 'bat.in']
+    extensions = [
+        'bash',
+        'bat.in',
+        'sh.in',
+        'zsh',
+    ]
     return ['local_setup.%s' % ext for ext in extensions] + \
         ['_order_isolated_packages.py']
-        # + ['setup.%s' % ext for ext in extensions]
+    # + ['setup.%s' % ext for ext in extensions]
 
 
 def get_isolated_prefix_level_template_path(name):

--- a/ament_package/templates.py
+++ b/ament_package/templates.py
@@ -23,7 +23,7 @@ def get_environment_hook_template_path(name):
 
 
 def get_package_level_template_names():
-    return ['local_setup.%s.in' % ext for ext in ['bash', 'sh', 'zsh']]
+    return ['local_setup.%s.in' % ext for ext in ['bash', 'sh', 'zsh', 'bat']]
 
 
 def get_package_level_template_path(name):
@@ -31,7 +31,7 @@ def get_package_level_template_path(name):
 
 
 def get_prefix_level_template_names():
-    extensions = ['bash', 'sh.in', 'zsh']
+    extensions = ['bash', 'sh.in', 'zsh', 'bat.in']
     return ['local_setup.%s' % ext for ext in extensions] + \
         ['setup.%s' % ext for ext in extensions]
 
@@ -41,7 +41,7 @@ def get_prefix_level_template_path(name):
 
 
 def get_isolated_prefix_level_template_names():
-    extensions = ['bash', 'sh.in', 'zsh']
+    extensions = ['bash', 'sh.in', 'zsh', 'bat.in']
     return ['local_setup.%s' % ext for ext in extensions] + \
         ['_order_isolated_packages.py']
         # + ['setup.%s' % ext for ext in extensions]


### PR DESCRIPTION
This pull request adds support for Windows by providing and exposing `.bat` versions of the `.sh` prefix level and package level `local_setup` and `setup` template files.

There is still work to be done here:

- [x] ~~The prefix level `setup.bat.in` still contains shell code and needs to be converted to batch~~ https://github.com/ament/ament_package/issues/8
- [x] ~~The prefix level `local_setup.bat.in` still does not order environment hooks by file name~~ https://github.com/ament/ament_package/issues/7
- [x] ~~The isolated install's `local_setup.bat.in` needs to be tested~~ https://github.com/ros2/ros2/issues/17

Connects to ros2/ros2#9