### PR TITLE
fix error when pkg_resources is not importable

### DIFF
--- a/ament_package/__init__.py
+++ b/ament_package/__init__.py
@@ -21,10 +21,10 @@ try:
         __version__ = pkg_resources.require('ament_package')[0].version
     except pkg_resources.DistributionNotFound:
         __version__ = 'unset'
-except (ImportError, OSError):
+    finally:
+        del pkg_resources
+except ImportError:
     __version__ = 'unset'
-finally:
-    del pkg_resources
 
 PACKAGE_MANIFEST_FILENAME = 'package.xml'
 


### PR DESCRIPTION
If `pkg_resources` fails to import it was trying to `del` a non-existing variable.

I don't recall why the code was catching `OSError`. Since I don't see a use case for that I removed that as well.

@esteve @tfoote @wjwwood Please review.