### PR TITLE
use per package parent_prefix_path files, fix order of ament workspaces

### DIFF
--- a/ament_package/template/prefix_level/setup.bat.in
+++ b/ament_package/template/prefix_level/setup.bat.in
@@ -8,7 +8,7 @@
 : ${AMENT_SHELL:=sh}
 
 # find parent prefix path files for all packages under the current prefix
-_RESOURCES="$(\find "$AMENT_CURRENT_PREFIX/share/ament_parent_prefix_path" -mindepth 1 -maxdepth 1 2> /dev/null | \sort)"
+_RESOURCES="$(\find "$AMENT_CURRENT_PREFIX/share/ament_index/resource_index/parent_prefix_path" -mindepth 1 -maxdepth 1 2> /dev/null | \sort)"
 
 # function to append non-duplicate values to environment variables
 # using colons as separators and avoiding leading separators
@@ -61,7 +61,7 @@ ament_append_unique_value() {
   unset _listname
 }
 
-# iterate over all ament_parent_prefix_path files
+# iterate over all parent_prefix_path files
 _prefix_setup_IFS=$IFS
 IFS="
 "
@@ -71,7 +71,7 @@ if [ "$AMENT_SHELL" = "zsh" ]; then
   ament_zsh_to_array _RESOURCES
 fi
 for _resource in $_RESOURCES; do
-  # read the content of the ament_parent_prefix_path file
+  # read the content of the parent_prefix_path file
   _PARENT_PREFIX_PATH="$(\cat "$_resource")"
   # reverse the list
   _REVERSED_PARENT_PREFIX_PATH=""
@@ -84,7 +84,7 @@ for _resource in $_RESOURCES; do
     if [ -z "$_REVERSED_PARENT_PREFIX_PATH" ]; then
       _REVERSED_PARENT_PREFIX_PATH=$_path
     else
-      _REVERSED_PARENT_PREFIX_PATH=$_REVERSED_PARENT_PREFIX_PATH:$_path
+      _REVERSED_PARENT_PREFIX_PATH=$_path:$_REVERSED_PARENT_PREFIX_PATH
     fi
   done
   unset _PARENT_PREFIX_PATH

--- a/ament_package/template/prefix_level/setup.sh.in
+++ b/ament_package/template/prefix_level/setup.sh.in
@@ -8,7 +8,7 @@
 : ${AMENT_SHELL:=sh}
 
 # find parent prefix path files for all packages under the current prefix
-_RESOURCES="$(\find "$AMENT_CURRENT_PREFIX/share/ament_parent_prefix_path" -mindepth 1 -maxdepth 1 2> /dev/null | \sort)"
+_RESOURCES="$(\find "$AMENT_CURRENT_PREFIX/share/ament_index/resource_index/parent_prefix_path" -mindepth 1 -maxdepth 1 2> /dev/null | \sort)"
 
 # function to append non-duplicate values to environment variables
 # using colons as separators and avoiding leading separators
@@ -61,7 +61,7 @@ ament_append_unique_value() {
   unset _listname
 }
 
-# iterate over all ament_parent_prefix_path files
+# iterate over all parent_prefix_path files
 _prefix_setup_IFS=$IFS
 IFS="
 "
@@ -71,7 +71,7 @@ if [ "$AMENT_SHELL" = "zsh" ]; then
   ament_zsh_to_array _RESOURCES
 fi
 for _resource in $_RESOURCES; do
-  # read the content of the ament_parent_prefix_path file
+  # read the content of the parent_prefix_path file
   _PARENT_PREFIX_PATH="$(\cat "$_resource")"
   # reverse the list
   _REVERSED_PARENT_PREFIX_PATH=""
@@ -84,7 +84,7 @@ for _resource in $_RESOURCES; do
     if [ -z "$_REVERSED_PARENT_PREFIX_PATH" ]; then
       _REVERSED_PARENT_PREFIX_PATH=$_path
     else
-      _REVERSED_PARENT_PREFIX_PATH=$_REVERSED_PARENT_PREFIX_PATH:$_path
+      _REVERSED_PARENT_PREFIX_PATH=$_path:$_REVERSED_PARENT_PREFIX_PATH
     fi
   done
   unset _PARENT_PREFIX_PATH


### PR DESCRIPTION
Depends on ament/ament_cmake#17.

Also fixes the order when sourcing a workspace B which is built on top of a workspace A.