### PR TITLE
unset AMENT_SHELL at the end of the scripts

### DIFF
--- a/ament_package/template/prefix_level/local_setup.sh.in
+++ b/ament_package/template/prefix_level/local_setup.sh.in
@@ -71,4 +71,5 @@ unset ORDERED_AMENT_ENVIRONMENT_HOOKS
 unset _prefix_local_setup_AMENT_CURRENT_PREFIX
 IFS=$_prefix_local_setup_IFS
 unset _prefix_local_setup_IFS
+unset AMENT_SHELL
 unset AMENT_CURRENT_PREFIX

--- a/ament_package/template/prefix_level/setup.sh.in
+++ b/ament_package/template/prefix_level/setup.sh.in
@@ -104,6 +104,8 @@ unset _RESOURCES
 ament_append_unique_value _UNIQUE_PREFIX_PATH "$AMENT_CURRENT_PREFIX"
 unset AMENT_CURRENT_PREFIX
 
+# store AMENT_SHELL to restore it after each prefix
+_prefix_setup_AMENT_SHELL=$AMENT_SHELL
 # source local_setup.EXT or local_setup.sh file for each prefix path
 IFS=":"
 if [ "$AMENT_SHELL" = "zsh" ]; then
@@ -120,9 +122,13 @@ for _path in $_UNIQUE_PREFIX_PATH; do
       AMENT_CURRENT_PREFIX=$_path
     fi
     . "$_path/local_setup.$AMENT_SHELL"
+    # restore AMENT_SHELL after each prefix-level local_setup file
+    AMENT_SHELL=$_prefix_setup_AMENT_SHELL
   fi
 done
 unset _path
 IFS=$_prefix_setup_IFS
 unset _prefix_setup_IFS
+unset _prefix_setup_AMENT_SHELL
 unset _UNIQUE_PREFIX_PATH
+unset AMENT_SHELL


### PR DESCRIPTION
To prevent cross talk between two separate source calls.