### PR TITLE
fix AMENT_CURRENT_PREFIX available in non-sh shell environment hooks

### DIFF
--- a/ament_package/template/package_level/local_setup.bash.in
+++ b/ament_package/template/package_level/local_setup.bash.in
@@ -20,6 +20,8 @@ if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
   unset AMENT_ENVIRONMENT_HOOKS
 fi
 
+# restore AMENT_CURRENT_PREFIX before evaluating the environment hooks
+AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
 # list all environment hooks of this package
 @ENVIRONMENT_HOOKS@
 # source all shell-specific environment hooks of this package

--- a/ament_package/template/package_level/local_setup.zsh.in
+++ b/ament_package/template/package_level/local_setup.zsh.in
@@ -31,6 +31,8 @@ if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
   unset AMENT_ENVIRONMENT_HOOKS
 fi
 
+# restore AMENT_CURRENT_PREFIX before evaluating the environment hooks
+AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
 # list all environment hooks of this package
 @ENVIRONMENT_HOOKS@
 # source all shell-specific environment hooks of this package


### PR DESCRIPTION
Before `AMENT_CURRENT_PREFIX` was not set in non-sh environment hooks since the previously sourced `local_setup.sh` file unsets the variable.