### PR TITLE
fix IFS cross talk

### DIFF
--- a/ament_package/template/isolated_prefix_level/local_setup.sh.in
+++ b/ament_package/template/isolated_prefix_level/local_setup.sh.in
@@ -34,6 +34,8 @@ fi
 for _package in $_ORDERED_PACKAGES; do
   # restore AMENT_CURRENT_PREFIX for each prefix-level local_setup file
   AMENT_CURRENT_PREFIX="$_isolated_prefix_local_setup_AMENT_CURRENT_PREFIX/$_package"
+  # restore IFS before sourcing other files
+  IFS=$_isolated_prefix_local_setup_IFS
   # bypass prefix-level local_setup file for performance reasons
   _path="$AMENT_CURRENT_PREFIX/share/$_package/local_setup.$AMENT_SHELL"
   # trace output

--- a/ament_package/template/package_level/local_setup.bash.in
+++ b/ament_package/template/package_level/local_setup.bash.in
@@ -32,8 +32,8 @@ if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
   for _hook in $AMENT_ENVIRONMENT_HOOKS; do
     # restore AMENT_CURRENT_PREFIX for each environment hook
     AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
-    # do not provide a field separator for environment hooks
-    unset IFS
+    # restore IFS before sourcing other files
+    IFS=$_package_local_setup_IFS
     . "$_hook"
   done
   unset _hook

--- a/ament_package/template/package_level/local_setup.sh.in
+++ b/ament_package/template/package_level/local_setup.sh.in
@@ -103,12 +103,12 @@ if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
   fi
   for _hook in $AMENT_ENVIRONMENT_HOOKS; do
     if [ -f "$_hook" ]; then
+      # restore IFS before sourcing other files
+      IFS=$_package_local_setup_IFS
       # trace output
       if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
         echo ". \"$_hook\""
       fi
-      # do not provide a field separator for environment hooks
-      unset IFS
       . "$_hook"
     fi
   done

--- a/ament_package/template/package_level/local_setup.zsh.in
+++ b/ament_package/template/package_level/local_setup.zsh.in
@@ -43,8 +43,8 @@ if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
   for _hook in $AMENT_ENVIRONMENT_HOOKS; do
     # restore AMENT_CURRENT_PREFIX for each environment hook
     AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
-    # do not provide a field separator for environment hooks
-    unset IFS
+    # restore IFS before sourcing other files
+    IFS=$_package_local_setup_IFS
     . "$_hook"
   done
   unset _hook

--- a/ament_package/template/prefix_level/local_setup.sh.in
+++ b/ament_package/template/prefix_level/local_setup.sh.in
@@ -34,6 +34,8 @@ fi
 for _package in $_ORDERED_PACKAGES; do
   # restore AMENT_CURRENT_PREFIX for each prefix-level local_setup file
   AMENT_CURRENT_PREFIX="$_prefix_local_setup_AMENT_CURRENT_PREFIX"
+  # restore IFS before sourcing other files
+  IFS=$_prefix_local_setup_IFS
   _path="$AMENT_CURRENT_PREFIX/share/$_package/local_setup.$AMENT_SHELL"
   # trace output
   if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then

--- a/ament_package/template/prefix_level/setup.sh.in
+++ b/ament_package/template/prefix_level/setup.sh.in
@@ -121,6 +121,8 @@ for _path in $_UNIQUE_PREFIX_PATH; do
       # provide AMENT_CURRENT_PREFIX to .sh files
       AMENT_CURRENT_PREFIX=$_path
     fi
+    # restore IFS before sourcing other files
+    IFS=$_prefix_setup_IFS
     . "$_path/local_setup.$AMENT_SHELL"
     # restore AMENT_SHELL after each prefix-level local_setup file
     AMENT_SHELL=$_prefix_setup_AMENT_SHELL


### PR DESCRIPTION
The first commit fixes #28.

The second commit unifies handling of IFS by always resetting it before souring other files.