### PR TITLE
improve python3 fallback executable logic in local_setup.sh

### DIFF
--- a/ament_package/template/prefix_level/local_setup.sh.in
+++ b/ament_package/template/prefix_level/local_setup.sh.in
@@ -15,7 +15,13 @@ if [ -n "$AMENT_PYTHON_EXECUTABLE" ]; then
 fi
 # if the Python executable doesn't exist try another fall back
 if [ ! -f "$_ament_python_executable" ]; then
-  _ament_python_executable="/usr/bin/env python3"
+  if /usr/bin/env python3 --version > /dev/null
+  then
+    _ament_python_executable=`/usr/bin/env python3 -c "import sys; print(sys.executable)"`
+  else
+    echo error: unable to find fallback python3 executable
+    return 1
+  fi
 fi
 
 # get all packages in topological order


### PR DESCRIPTION
Without this improvement, the alpha3 OS X binary returns this when I was testing it:

```
% source ./setup.zsh
/Users/william/testing_alpha3/ros2-osx/local_setup.sh:22: no such file or directory: /usr/bin/env python3
```

See related issue: https://github.com/ros2/ros2/issues/141