### PR TITLE
prevent keyword arguments to be called as positional argument

### DIFF
--- a/ament_package/export.py
+++ b/ament_package/export.py
@@ -16,7 +16,7 @@
 class Export(object):
     __slots__ = ['tagname', 'attributes', 'content']
 
-    def __init__(self, tagname, attributes=None, content=None):
+    def __init__(self, tagname, *, attributes=None, content=None):
         self.tagname = tagname
         self.attributes = dict(attributes) if attributes else {}
         self.content = content

--- a/ament_package/package.py
+++ b/ament_package/package.py
@@ -44,7 +44,7 @@ class Package(object):
         'filename'
     ]
 
-    def __init__(self, filename=None, **kwargs):
+    def __init__(self, *, filename=None, **kwargs):
         """
         Constructor.
 

--- a/ament_package/person.py
+++ b/ament_package/person.py
@@ -20,7 +20,7 @@ from .exceptions import InvalidPackage
 class Person(object):
     __slots__ = ['name', 'email']
 
-    def __init__(self, name, email=None):
+    def __init__(self, name, *, email=None):
         self.name = name
         self.email = email
 

--- a/ament_package/templates.py
+++ b/ament_package/templates.py
@@ -39,7 +39,7 @@ def get_package_level_template_path(name):
     return os.path.join(TEMPLATE_DIRECTORY, 'package_level', name)
 
 
-def get_prefix_level_template_names(all_platforms=False):
+def get_prefix_level_template_names(*, all_platforms=False):
     extensions = [
         'bash',
         'bat.in',
@@ -58,7 +58,7 @@ def get_prefix_level_template_path(name):
     return os.path.join(TEMPLATE_DIRECTORY, 'prefix_level', name)
 
 
-def get_isolated_prefix_level_template_names(all_platforms=False):
+def get_isolated_prefix_level_template_names(*, all_platforms=False):
     extensions = [
         'bash',
         'bat.in',

--- a/ament_package/url.py
+++ b/ament_package/url.py
@@ -16,9 +16,9 @@
 class Url(object):
     __slots__ = ['url', 'type']
 
-    def __init__(self, url, type_=None):
+    def __init__(self, url, *, url_type=None):
         self.url = url
-        self.type = type_
+        self.type = url_type
 
     def __str__(self):
         return self.url

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -51,7 +51,7 @@ class PackageTest(unittest.TestCase):
         self.assertEqual([], pack.conflicts)
         self.assertEqual([], pack.replaces)
         self.assertEqual([], pack.exports)
-        pack = Package('foo',
+        pack = Package(filename='foo',
                        name='bar',
                        version='0.0.0',
                        licenses=['BSD'],
@@ -76,7 +76,7 @@ class PackageTest(unittest.TestCase):
         self.assertRaises(TypeError, Dependency, 'foo', unknownattribute=42)
 
     def test_init_kwargs_string(self):
-        pack = Package('foo',
+        pack = Package(filename='foo',
                        name='bar',
                        package_format='1',
                        version='0.0.0',
@@ -125,7 +125,7 @@ class PackageTest(unittest.TestCase):
 
     def test_validate_package(self):
         maint = self.get_maintainer()
-        pack = Package('foo',
+        pack = Package(filename='foo',
                        name='bar_2go',
                        package_format='1',
                        version='0.0.0',


### PR DESCRIPTION
Ensure that keyword args are actually be passed as keyword args.

CI passes: http://ci.ros2.org/job/ci_osx/747/