### PR TITLE
Open package.xml file as UTF-8

### DIFF
--- a/ament_package/__init__.py
+++ b/ament_package/__init__.py
@@ -55,7 +55,7 @@ def parse_package(path):
         raise IOError("Path '%s' is neither a directory containing a '%s' "
                       "file nor a file" % (path, PACKAGE_MANIFEST_FILENAME))
 
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         try:
             return parse_package_string(f.read(), filename=filename)
         except InvalidPackage as e:


### PR DESCRIPTION
Without this change, this is the error I get when building ROS2 inside a Docker container:

```
esteve@eobard:/tmp/ros2$ docker run -v `pwd`:/ros2 -w /ros2 ros2-ubuntu-xenial /ros2/src/ament/ament_tools/scripts/ament.py build --isolated --symlink-install
Traceback (most recent call last):
  File "/ros2/src/ament/ament_tools/scripts/ament.py", line 149, in <module>
    sys.exit(main() or 0)
  File "/ros2/src/ament/ament_tools/ament_tools/commands/ament.py", line 88, in main
    rc = args.main(args)
  File "/ros2/src/ament/ament_tools/ament_tools/verbs/build/cli.py", line 142, in main
    packages = topological_order(opts.basepath)
  File "/ros2/src/ament/ament_tools/ament_tools/topological_order.py", line 103, in topological_order
    packages = _find_unique_packages(root_dir)
  File "/ros2/src/ament/ament_tools/ament_tools/packages.py", line 81, in find_unique_packages
    packages = find_packages(basepath, exclude_paths=exclude_paths)
  File "/ros2/src/ament/ament_tools/ament_tools/packages.py", line 66, in find_packages
    packages[path] = parse_package(os.path.join(basepath, path))
  File "/ros2/src/ament/ament_tools/ament_tools/package_types/__init__.py", line 31, in parse_package
    pkg = package_type['parse_package'](path)
  File "/ros2/src/ament/ament_package/ament_package/__init__.py", line 60, in parse_package
    return parse_package_string(f.read(), filename=filename)
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 289: ordinal not in range(128)
```

caused by the 'á' in González from https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/blob/master/rmw_fastrtps_cpp/package.xml#L6

[Here'](https://gist.github.com/esteve/9fbdae14849798a82308249e3cccc020)s the Dockerfile I use to build the image and following is the command I run to build ROS2:

```
docker run -v `pwd`:/ros2 -w /ros2 ros2-ubuntu-xenial /ros2/src/ament/ament_tools/scripts/ament.py build --isolated --symlink-install
```

