### PR TITLE
add schema to manifest

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>ament_package</name>
   <version>0.0.0</version>


### PR DESCRIPTION
With the schema for package manifests being available (ros-infrastructure/rep#117) we should start using them.

After this has been +1ed and merged I would propose to apply the same change to all other packages (without making PRs for the change though).