### PR TITLE
added better features for finding python

### DIFF
--- a/ament_package/template/isolated_prefix_level/local_setup.bat.in
+++ b/ament_package/template/isolated_prefix_level/local_setup.bat.in
@@ -24,14 +24,22 @@ goto:eof
   setlocal enabledelayedexpansion
 
   :: use the Python executable known at configure time
-  set "ament_python_executable=@PYTHON_EXECUTABLE@"
+  set "_ament_python_executable=@PYTHON_EXECUTABLE@"
   :: allow overriding it with a custom location
   if "%AMENT_PYTHON_EXECUTABLE%" NEQ "" (
-    set "ament_python_executable=%AMENT_PYTHON_EXECUTABLE%"
+    set "_ament_python_executable=%AMENT_PYTHON_EXECUTABLE%"
+  )
+  if NOT exist %_ament_python_executable% (
+    for %%I in (python.exe) do set "exepath=%%~$PATH:I"
+    if "!exepath!" NEQ "" set "_ament_python_executable=!exepath!"
+  )
+  if NOT exist %_ament_python_executable% (
+    echo could not find python: install python with chocolatey, add a folder to it in the PATH variable, or set AMENT_PYTHON_EXECUTABLE
+    goto:eof
   )
 
   set "ordered_packages="
-  for /f %%p in ('""%ament_python_executable%" "%~dp0_order_isolated_packages.py" "%~2\""') do (
+  for /f %%p in ('""%_ament_python_executable%" "%~dp0_order_isolated_packages.py" "%~2\""') do (
     if "!ordered_packages!" NEQ "" set "ordered_packages=!ordered_packages!;"
     set "ordered_packages=!ordered_packages!%%p"
   )

--- a/ament_package/template/isolated_prefix_level/local_setup.bat.in
+++ b/ament_package/template/isolated_prefix_level/local_setup.bat.in
@@ -30,8 +30,9 @@ goto:eof
     set "_ament_python_executable=%AMENT_PYTHON_EXECUTABLE%"
   )
   if NOT exist %_ament_python_executable% (
-    for %%I in (python.exe) do set "exepath=%%~$PATH:I"
-    if "!exepath!" NEQ "" set "_ament_python_executable=!exepath!"
+    for %%I in (python.exe) do (
+      if "%%~$PATH:I" NEQ "" set "_ament_python_executable=%%~$PATH:I"
+    )
   )
   if NOT exist %_ament_python_executable% (
     echo Could not find Python executable: either add the folder of the Python executable (e.g. installed with Chocolatey) to the PATH variable or explicitly set the environment variable AMENT_PYTHON_EXECUTABLE to the full path of the Python executable

--- a/ament_package/template/isolated_prefix_level/local_setup.bat.in
+++ b/ament_package/template/isolated_prefix_level/local_setup.bat.in
@@ -34,7 +34,7 @@ goto:eof
     if "!exepath!" NEQ "" set "_ament_python_executable=!exepath!"
   )
   if NOT exist %_ament_python_executable% (
-    echo could not find python: install python with chocolatey, add a folder to it in the PATH variable, or set AMENT_PYTHON_EXECUTABLE
+    echo Could not find Python executable: either add the folder of the Python executable (e.g. installed with Chocolatey) to the PATH variable or explicitly set the environment variable AMENT_PYTHON_EXECUTABLE to the full path of the Python executable
     goto:eof
   )
 


### PR DESCRIPTION
This PR refers to https://github.com/ament/ament_package/issues/43.

It looks like the variable naming is not case sensitive so the script did not allow for the path to be overwritten. Finding python in the path and printing a helpful error was also added.