### PR TITLE
Allow package names to be warnings and collect warnings in Package object

### DIFF
--- a/ament_package/__init__.py
+++ b/ament_package/__init__.py
@@ -84,6 +84,9 @@ def parse_package_string(data, *, filename=None):
     """
     Parse package.xml string contents.
 
+    Any warnings are stored in the ``parsing_warnings`` member of the
+    returned package obj.
+
     :param data: package.xml contents, ``str``
     :param filename: full file path for debugging, ``str``
     :returns: return parsed :class:`Package`
@@ -291,7 +294,7 @@ def parse_package_string(data, *, filename=None):
             'Error(s) in %s:%s' %
             (filename, ''.join(['\n- %s' % e for e in errors])))
 
-    pkg.validate()
+    pkg.parsing_warnings = pkg.validate(package_name_warning_not_error=True)
 
     return pkg
 

--- a/ament_package/__init__.py
+++ b/ament_package/__init__.py
@@ -29,9 +29,11 @@ except ImportError:
 PACKAGE_MANIFEST_FILENAME = 'package.xml'
 
 
-def parse_package(path):
+def parse_package(path, **kwargs):
     """
     Parse package manifest.
+
+    Any keyword arguments are passed along to parse_package_string().
 
     :param path: The path of the package.xml file, it may or may not
     include the filename
@@ -57,7 +59,7 @@ def parse_package(path):
 
     with open(filename, 'r', encoding='utf-8') as f:
         try:
-            return parse_package_string(f.read(), filename=filename)
+            return parse_package_string(f.read(), filename=filename, **kwargs)
         except InvalidPackage as e:
             e.args = [
                 "Invalid package manifest '%s': %s" %
@@ -80,7 +82,12 @@ def package_exists_at(path):
         os.path.join(path, PACKAGE_MANIFEST_FILENAME))
 
 
-def parse_package_string(data, *, filename=None):
+def parse_package_string(
+    data,
+    *,
+    filename=None,
+    package_name_warning_not_error=False
+):
     """
     Parse package.xml string contents.
 
@@ -89,6 +96,8 @@ def parse_package_string(data, *, filename=None):
 
     :param data: package.xml contents, ``str``
     :param filename: full file path for debugging, ``str``
+    :param package_name_warning_not_error: if True, some package name
+        violations are treated as warnings not errors, ``bool``
     :returns: return parsed :class:`Package`
     :raises: :exc:`InvalidPackage`
     """

--- a/ament_package/package.py
+++ b/ament_package/package.py
@@ -41,7 +41,8 @@ class Package(object):
         'conflicts',
         'replaces',
         'exports',
-        'filename'
+        'filename',
+        'parsing_warnings'
     ]
 
     def __init__(self, *, filename=None, **kwargs):
@@ -90,6 +91,7 @@ class Package(object):
 
         :raises InvalidPackage: in case validation fails
         """
+        warnings = []
         errors = []
         if self.package_format:
             if not re.match('^[1-9][0-9]*$', str(self.package_format)):
@@ -152,3 +154,5 @@ class Package(object):
 
         if errors:
             raise InvalidPackage('\n'.join(errors))
+
+        return warnings

--- a/ament_package/package.py
+++ b/ament_package/package.py
@@ -85,10 +85,13 @@ class Package(object):
             data[attr] = getattr(self, attr)
         return str(data)
 
-    def validate(self):
+    def validate(self, package_name_warning_not_error=False):
         """
         Ensure that all standards for packages are met.
 
+        :param package_name_warning_not_error: if True, some package name
+            violations are treated as warnings not errors
+        :returns: list of warnings as strings or an empty list if none
         :raises InvalidPackage: in case validation fails
         """
         warnings = []
@@ -103,8 +106,14 @@ class Package(object):
         # only allow lower case alphanummeric characters and underscores
         # must start with an alphabetic character
         if not re.match('^[a-z][a-z0-9_]*$', self.name):
-            errors.append("Package name '%s' does not follow naming "
-                          "conventions" % self.name)
+            msg = (
+                "Package name '%s' does not follow naming conventions"
+                % self.name
+            )
+            if package_name_warning_not_error:
+                warnings.append(msg)
+            else:
+                errors.append(msg)
 
         if not self.version:
             errors.append('Package version must not be empty')


### PR DESCRIPTION
This pull request does two things:

- Makes it possible to store warnings in the `Package` object
- Makes it possible to make name violations warnings rather than errors

I ran into this while trying to integrate `ceres-solver` into a build using `ament_tools`. While it is true this name is not "right", it's also annoying to have the build tool fail if I don't modify this code after cloning it (impossible on the farm without a fork). This is should also address https://github.com/ament/ament_package/issues/47.

I will have a matching pull request for the tools which checks all packages for these warnings and prints them when the tool exits to make sure the warning stays visible.

I first implemented this where the `parse_package` functions returned the `Package` object and the warnings separately, but passing that through all of our existing code was really painful. So I switched to this approach. I feel that the `filename` slot has is similar, in that it doesn't really describe the package, but something about how the `Package` object was generated.

This change should be backward compatible, since all new arguments are keyword arguments. It also does not change the existing behavior, since the filename violations default to errors as they are now. It does, however, mean that there is a new slot in the `Package` object, but I haven't run into any issues with that so far.