### PR TITLE
Add setuptools dependency for pkg_resources

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_export_depend>python3</buildtool_export_depend>
   
-  <depend>python-setuptools</depend>
+  <depend>python3-setuptools</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,8 @@
   <buildtool_depend>python3</buildtool_depend>
 
   <buildtool_export_depend>python3</buildtool_export_depend>
+  
+  <depend>python3_setuptools</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_export_depend>python3</buildtool_export_depend>
   
-  <depend>python3_setuptools</depend>
+  <depend>python-setuptools</depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
When using ament_package on the test buildfarm it failed due to the missing package pkg_resources.

Here's [an example failure using an ament_package binary on a downstream package](http://test.build.ros2.org/view/Rbin_uX64/job/Rbin_uX64__ament_cmake_core__ubuntu_xenial_amd64__binary/3/console#console-section-15). Grep for ImportError to see the exact line.

```
23:01:26 -- Found PythonInterp: /usr/bin/python3 (found suitable version "3.5.2", minimum required is "3") 
23:01:26 -- Using PYTHON_EXECUTABLE: /usr/bin/python3
23:01:26 -- ament_cmake_core 0.0.0
23:01:26 Traceback (most recent call last):
23:01:26   File "/tmp/binarydeb/ros-r2b2-ament-cmake-core-0.0.0/cmake/package_templates/templates_2_cmake.py", line 21, in <module>
23:01:26     from ament_package.templates import get_environment_hook_template_path
23:01:26   File "/usr/lib/python3.5/dist-packages/ament_package/templates.py", line 16, in <module>
23:01:26     import pkg_resources
23:01:26 ImportError: No module named 'pkg_resources'
```