### PR TITLE
Allow dashes in non-catkin/ament* package names

### DIFF
--- a/ament_package/package.py
+++ b/ament_package/package.py
@@ -112,19 +112,11 @@ class Package(object):
 
         if not self.name:
             errors.append('Package name must not be empty')
-        # assume packages are catkin unless a build_type is exported.
-        build_type = 'catkin'
-        build_types = [ex.contents for ex in self.exports if ex.tagname == 'build_type']
-        if len(build_types) > 1:
-            # this is bad, but first I must ask if we should make this an error.
-            pass
-        elif len(build_types) == 1:
-            build_type = build_types[0]
         valid_package_name_regexp = '^[a-z][a-z0-9_]*$'
-        # must start with an alphabetic character
-        # only allow lower case alphanummeric characters, underscores in catkin or
-        # ament packages. Dashes are allowed for other build_types.
-        if not re.match('^(ament[a-z0-9_]*|catkin)$', build_type):
+        # must start with an alphabetic character only allow lower case
+        # alphanummeric characters and underscores in catkin or ament packages.
+        # Dashes are allowed for other build_types.
+        if not re.match('^(ament[a-z0-9_]*|catkin)$', self.get_build_type()):
             valid_package_name_regexp = '^[a-z][a-z0-9_-]*$'
         if not re.match(valid_package_name_regexp, self.name):
             errors.append("Package name '%s' does not follow naming "

--- a/ament_package/package.py
+++ b/ament_package/package.py
@@ -91,7 +91,7 @@ class Package(object):
         :rtype: str
         :raises: :exc:`InvalidPackage`
         """
-        build_type_exports = [ex.contents for ex in self.exports if ex.tagname == 'build_type']
+        build_type_exports = [ex.content for ex in self.exports if ex.tagname == 'build_type']
         if not build_type_exports:
             return 'catkin'
         if len(build_type_exports) == 1:

--- a/ament_package/package.py
+++ b/ament_package/package.py
@@ -112,8 +112,9 @@ class Package(object):
 
         if not self.name:
             errors.append('Package name must not be empty')
-        # must start with an alphabetic character only allow lower case
-        # alphanummeric characters and underscores in catkin or ament packages.
+        # Must start with a lower case alphabetic character.
+        # Allow lower case alphanummeric characters and underscores in
+        # catkin or ament packages.
         valid_package_name_regexp = '^[a-z][a-z0-9_]*$'
         build_type = self.get_build_type()
         if build_type != 'catkin' and not build_type.startswith('ament'):

--- a/ament_package/package.py
+++ b/ament_package/package.py
@@ -84,6 +84,20 @@ class Package(object):
             data[attr] = getattr(self, attr)
         return str(data)
 
+    def get_build_type(self):
+        """
+        Return value of export/build_type element, or 'catkin' if unspecified.
+        :returns: package build type
+        :rtype: str
+        :raises: :exc:`InvalidPackage`
+        """
+        build_type_exports = [ex.contents for ex in self.exports if ex.tagname == 'build_type']
+        if not build_type_exports:
+            return 'catkin'
+        if len(build_type_exports) == 1:
+            return build_type_exports[0]
+        raise InvalidPackage('Only one <build_type> element is permitted.')
+
     def validate(self):
         """
         Ensure that all standards for packages are met.

--- a/ament_package/package.py
+++ b/ament_package/package.py
@@ -112,12 +112,12 @@ class Package(object):
 
         if not self.name:
             errors.append('Package name must not be empty')
-        valid_package_name_regexp = '^[a-z][a-z0-9_]*$'
         # must start with an alphabetic character only allow lower case
         # alphanummeric characters and underscores in catkin or ament packages.
-        # Dashes are allowed for other build_types.
+        valid_package_name_regexp = '^[a-z][a-z0-9_]*$'
         build_type = self.get_build_type()
         if build_type != 'catkin' and not build_type.startswith('ament'):
+            # Dashes are allowed for other build_types.
             valid_package_name_regexp = '^[a-z][a-z0-9_-]*$'
         if not re.match(valid_package_name_regexp, self.name):
             errors.append("Package name '%s' does not follow naming "

--- a/ament_package/package.py
+++ b/ament_package/package.py
@@ -98,9 +98,21 @@ class Package(object):
 
         if not self.name:
             errors.append('Package name must not be empty')
-        # only allow lower case alphanummeric characters and underscores
+        # assume packages are catkin unless a build_type is exported.
+        build_type = 'catkin'
+        build_types = [ex.contents for ex in self.exports if ex.tagname == 'build_type']
+        if len(build_types) > 1:
+            # this is bad, but first I must ask if we should make this an error.
+            pass
+        elif len(build_types) == 1:
+            build_type = build_types[0]
+        valid_package_name_regexp = '^[a-z][a-z0-9_]*$'
         # must start with an alphabetic character
-        if not re.match('^[a-z][a-z0-9_]*$', self.name):
+        # only allow lower case alphanummeric characters, underscores in catkin or
+        # ament packages. Dashes are allowed for other build_types.
+        if not re.match('^(ament[a-z0-9_]*|catkin)$', build_type):
+            valid_package_name_regexp = '^[a-z][a-z0-9_-]*$'
+        if not re.match(valid_package_name_regexp, self.name):
             errors.append("Package name '%s' does not follow naming "
                           "conventions" % self.name)
 

--- a/ament_package/package.py
+++ b/ament_package/package.py
@@ -116,7 +116,8 @@ class Package(object):
         # must start with an alphabetic character only allow lower case
         # alphanummeric characters and underscores in catkin or ament packages.
         # Dashes are allowed for other build_types.
-        if not re.match('^(ament[a-z0-9_]*|catkin)$', self.get_build_type()):
+        build_type = self.get_build_type()
+        if build_type != 'catkin' and not build_type.startswith('ament'):
             valid_package_name_regexp = '^[a-z][a-z0-9_-]*$'
         if not re.match(valid_package_name_regexp, self.name):
             errors.append("Package name '%s' does not follow naming "

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -146,15 +146,15 @@ class PackageTest(unittest.TestCase):
         pack.name = 'bar-bza'
         self.assertRaises(InvalidPackage, Package.validate, pack)
         # check explicit catkin and ament_* build_types
-        build_type = Mock(tagname='build_type', attributes={}, contents='catkin')
+        build_type = Mock(tagname='build_type', attributes={}, content='catkin')
         pack.exports = [build_type]
         self.assertRaises(InvalidPackage, Package.validate, pack)
-        build_type.contents = 'ament_cmake'
+        build_type.content = 'ament_cmake'
         self.assertRaises(InvalidPackage, Package.validate, pack)
-        build_type.contents = 'ament_python'
+        build_type.content = 'ament_python'
         self.assertRaises(InvalidPackage, Package.validate, pack)
         # check non ament/catkin build type is valid
-        build_type.contents = 'cmake'
+        build_type.content = 'cmake'
         pack.validate()
         # check authors emails
         pack.name = 'bar'

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -138,10 +138,24 @@ class PackageTest(unittest.TestCase):
         self.assertRaises(InvalidPackage, Package.validate, pack)
         pack.name = 'bar bza'
         self.assertRaises(InvalidPackage, Package.validate, pack)
-        pack.name = 'bar-bza'
-        self.assertRaises(InvalidPackage, Package.validate, pack)
         pack.name = 'BAR'
         self.assertRaises(InvalidPackage, Package.validate, pack)
+        # dashes should be acceptable in packages other than catkin or
+        # ament_*.
+        # no build_type, so catkin is assumed per REP-140.
+        pack.name = 'bar-bza'
+        self.assertRaises(InvalidPackage, Package.validate, pack)
+        # check explicit catkin and ament_* build_types
+        build_type = Mock(tagname='build_type', attributes={}, contents='catkin')
+        pack.exports = [build_type]
+        self.assertRaises(InvalidPackage, Package.validate, pack)
+        build_type.contents = 'ament_cmake'
+        self.assertRaises(InvalidPackage, Package.validate, pack)
+        build_type.contents = 'ament_python'
+        self.assertRaises(InvalidPackage, Package.validate, pack)
+        # check non ament/catkin build type is valid
+        build_type.contents = 'cmake'
+        pack.validate()
         # check authors emails
         pack.name = 'bar'
         auth1 = Mock()

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -141,7 +141,7 @@ class PackageTest(unittest.TestCase):
         pack.name = 'BAR'
         self.assertRaises(InvalidPackage, Package.validate, pack)
         # dashes should be acceptable in packages other than catkin or
-        # ament_*.
+        # ament*.
         # no build_type, so catkin is assumed per REP-140.
         pack.name = 'bar-bza'
         self.assertRaises(InvalidPackage, Package.validate, pack)


### PR DESCRIPTION
If a package has a build type other than catkin or ament*, allow a dash in the name.

This mirrors the catkin change in ros-infrastructure/catkin_pkg#162 which enables support for the package name exceptions for dashes in http://www.ros.org/reps/rep-0140.html#name

The python here is pretty hairy as I'm still getting used to it. I'll be happy to restructure any of the changes here based on feedback.