### PR TITLE
Remove python3 dependencies implied by ament_python build type.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,10 +7,6 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>python3</buildtool_depend>
-
-  <buildtool_export_depend>python3</buildtool_export_depend>
-
   <depend>python3-setuptools</depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
From https://github.com/ros/rosdistro/pull/15328 there is no longer a rosdep key for `python3`.
All ament_python packages have injected build_depends on Debian packages python3-all, dh-python, and python3-setuptools.
The Debian package builder also adds python runtime dependencies as it sees fit via the `${python3:Depends}` helper.

I think there's a long term danger of too-closely relying on assumed dependencies, particularly for platform-specific builds, but for consistency with other ament_python packages I have removed these here.

If we want to leave these dependencies untouched in the source package.xml, they'll need to be patched out at release time since there is no longer a rosdep key `python3`.