### PR TITLE
check if path exists before trying to list dir

### DIFF
--- a/ament_package/template/prefix_level/_order_packages.py
+++ b/ament_package/template/prefix_level/_order_packages.py
@@ -32,7 +32,7 @@ def main(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
 
     path = os.path.join(args.root, 'share', 'ament_index', 'resource_index', 'packages')
-    package_names = [d for d in os.listdir(path)]
+    package_names = os.listdir(path) if os.path.exists(path) else []
     run_dependencies = {}
     for pkg_name in package_names:
         run_dependencies[pkg_name] = []


### PR DESCRIPTION
Fixes #48.

I don't think this case needs a warning. If the prefix is empty or the packages didn't register themselves at the index that seems to be ok to me.