### PR TITLE
add Scripts to PATH on Windows

### DIFF
--- a/ament_package/template/environment_hook/ament_prefix_path.bat
+++ b/ament_package/template/environment_hook/ament_prefix_path.bat
@@ -15,6 +15,10 @@ goto:eof
   :: arguments
   set "listname=%~1"
   set "value=%~2"
+  :: skip if path doesn't exist
+  if NOT EXIST "%value%" (
+    goto:eof
+  )
   :: expand the list variable
   set "list=!%listname%!"
   :: check if the list contains the value

--- a/ament_package/template/environment_hook/path.bat
+++ b/ament_package/template/environment_hook/path.bat
@@ -16,6 +16,10 @@ goto:eof
   :: arguments
   set "listname=%~1"
   set "value=%~2"
+  :: skip if path doesn't exist
+  if NOT EXIST "%value%" (
+    goto:eof
+  )
   :: expand the list variable
   set "list=!%listname%!"
   :: check if the list contains the value

--- a/ament_package/template/environment_hook/path.bat
+++ b/ament_package/template/environment_hook/path.bat
@@ -2,6 +2,7 @@
 @echo off
 
 call:ament_prepend_unique_value PATH "%AMENT_CURRENT_PREFIX%\bin"
+call:ament_prepend_unique_value PATH "%AMENT_CURRENT_PREFIX%\Scripts"
 
 goto:eof
 

--- a/ament_package/template/environment_hook/pythonpath.bat.in
+++ b/ament_package/template/environment_hook/pythonpath.bat.in
@@ -15,6 +15,10 @@ goto:eof
   :: arguments
   set "listname=%~1"
   set "value=%~2"
+  :: skip if path doesn't exist
+  if NOT EXIST "%value%" (
+    goto:eof
+  )
   :: expand the list variable
   set "list=!%listname%!"
   :: check if the list contains the value


### PR DESCRIPTION
Work around different default installation path for Python scripts on Windows, see https://github.com/ament/ament_tools/pull/156#issuecomment-323198512.

Before: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3112)](http://ci.ros2.org/job/ci_windows/3112/)
After: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3113)](http://ci.ros2.org/job/ci_windows/3113/) (much further - but not all the way yet...)