### PR TITLE
python-ament-package -> python3-ament-package

### DIFF
--- a/ament_package/__init__.py
+++ b/ament_package/__init__.py
@@ -126,7 +126,7 @@ def parse_package_string(data, *, filename=None):
     assert pkg.package_format in [2], \
         "Unable to handle '%s' format version '%d', please update " \
         "'ament_package' (e.g. on Ubuntu/Debian use: sudo apt-get update && " \
-        'sudo apt-get install --only-upgrade python-ament-package)' % \
+        'sudo apt-get install --only-upgrade python3-ament-package)' % \
         (filename, pkg.package_format)
 
     # name


### PR DESCRIPTION
as I expect python-ament-package to never exist and hope we'll have python packages released without the ros namespace in the near future