### PR TITLE
support file attribution of license tag

### DIFF
--- a/ament_package/__init__.py
+++ b/ament_package/__init__.py
@@ -169,7 +169,7 @@ def parse_package_string(data, *, filename=None):
     for node in licenses:
         pkg.licenses.append(License(
             _get_node_value(node),
-            file=_get_node_attr(node, 'file', default=None)))
+            file_=_get_node_attr(node, 'file', default=None)))
 
     errors = []
     # dependencies and relationships

--- a/ament_package/__init__.py
+++ b/ament_package/__init__.py
@@ -94,6 +94,7 @@ def parse_package_string(data, *, filename=None):
 
     from .exceptions import InvalidPackage
     from .export import Export
+    from .license import License
     from .package import Package
     from .person import Person
     from .url import Url
@@ -166,7 +167,9 @@ def parse_package_string(data, *, filename=None):
     # at least one license
     licenses = _get_nodes(root, 'license')
     for node in licenses:
-        pkg.licenses.append(_get_node_value(node))
+        pkg.licenses.append(License(
+            _get_node_value(node),
+            file=_get_node_attr(node, 'file', default=None)))
 
     errors = []
     # dependencies and relationships

--- a/ament_package/license.py
+++ b/ament_package/license.py
@@ -16,9 +16,9 @@
 class License:
     __slots__ = ['name', 'file']
 
-    def __init__(self, name, *, file=None):
+    def __init__(self, name, *, file_=None):
         self.name = name
-        self.file = file
+        self.file = file_
 
     def __str__(self):
         return self.name

--- a/ament_package/license.py
+++ b/ament_package/license.py
@@ -1,0 +1,24 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class License:
+    __slots__ = ['name', 'file']
+
+    def __init__(self, name, *, file=None):
+        self.name = name
+        self.file = file
+
+    def __str__(self):
+        return self.name

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -113,7 +113,7 @@ class PackageTest(unittest.TestCase):
 
     def test_init_kwargs_object(self):
         mmain = [self.get_maintainer(), self.get_maintainer()]
-        mlis = [License('MIT'), License('BSD', file='LICENSE')]
+        mlis = [License('MIT'), License('BSD', file_='LICENSE')]
         mauth = [self.get_maintainer(), self.get_maintainer()]
         murl = [Mock(), Mock()]
         mbuilddep = [Mock(), Mock()]

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -17,6 +17,7 @@ import unittest
 
 from ament_package.dependency import Dependency
 from ament_package.exceptions import InvalidPackage
+from ament_package.license import License
 from ament_package.package import Package
 from ament_package.person import Person
 from mock import Mock
@@ -112,7 +113,7 @@ class PackageTest(unittest.TestCase):
 
     def test_init_kwargs_object(self):
         mmain = [self.get_maintainer(), self.get_maintainer()]
-        mlis = ['MIT', 'BSD']
+        mlis = [License('MIT'), License('BSD', file='LICENSE')]
         mauth = [self.get_maintainer(), self.get_maintainer()]
         murl = [Mock(), Mock()]
         mbuilddep = [Mock(), Mock()]


### PR DESCRIPTION
Implemented https://github.com/ros-infrastructure/rep/pull/157.

Thanks.
