### PR TITLE
Drop dependency on pyparsing.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,6 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <depend>python3-pyparsing</depend>
   <depend>python3-setuptools</depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
The code which required pyparsing was dropped in https://github.com/ament/ament_package/pull/75.

Incidentally it doesn't appear that the pyparsing dependency was ever added to setup.py. In general we want to keep setup.py and package.xml dependencies in sync right?