### PR TITLE
Release 0.5.1

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>ament_package</name>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
   <description>The parser for the manifest files in the ament buildsystem.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='ament_package',
-    version='0.4.0',
+    version='0.5.1',
     packages=find_packages(exclude=['test']),
     zip_safe=True,
     author='Dirk Thomas',


### PR DESCRIPTION
Planning to tag the merged version of this commit as `0.5.1` in order to release it into Bouncy.
When bumping I noticed that the setup.py wasn't updated for 0.5.0. I bumped it here but I can undo that if it was intentionally left as is.
