### PR TITLE
fix custom zsh logic for handling arrays

### DIFF
--- a/ament_package/template/package_level/local_setup.zsh.in
+++ b/ament_package/template/package_level/local_setup.zsh.in
@@ -1,5 +1,7 @@
 # generated from ament_package/template/package_level/local_setup.zsh.in
 
+AMENT_SHELL=zsh
+
 # source local_setup.sh from same directory as this file
 _this_path=$(builtin cd -q "`dirname "${(%):-%N}"`" > /dev/null && pwd)
 # provide AMENT_CURRENT_PREFIX to shell script


### PR DESCRIPTION
Fixes ros2/ros2#546.

Otherwise when sourcing a package-level script it doesn't perform the `ament_zsh_to_array` function and therefore doesn't source package environment hooks.