### PR TITLE
Fix lint warnings from invalid escape sequences

### DIFF
--- a/ament_package/templates.py
+++ b/ament_package/templates.py
@@ -111,7 +111,7 @@ def configure_string(template, environment):
         if var in environment:
             return environment[var]
         return ''
-    return re.sub('\@[a-zA-Z0-9_]+\@', substitute, template)
+    return re.sub(r'\@[a-zA-Z0-9_]+\@', substitute, template)
 
 
 def _is_platform_specific_extension(filename):


### PR DESCRIPTION
Use raw strings for regex patterns to avoid warnings.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5348)](http://ci.ros2.org/job/ci_linux/5348/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2078)](http://ci.ros2.org/job/ci_linux-aarch64/2078/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4441)](http://ci.ros2.org/job/ci_osx/4441/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5311)](http://ci.ros2.org/job/ci_windows/5311/)