### PR TITLE
Prepare release of 0.6.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>ament_package</name>
-  <version>0.5.2</version>
+  <version>0.6.0</version>
   <description>The parser for the manifest files in the ament buildsystem.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='ament_package',
-    version='0.5.2',
+    version='0.6.0',
     packages=find_packages(exclude=['test']),
     zip_safe=True,
     author='Dirk Thomas',


### PR DESCRIPTION
There isn't currently a changelog to update for this package so there's very little in this "draft" release commit except to notify that I'm making the release. Using 0.6.0 allows us room to make future changes to the 0.5.x track in bouncy.