### PR TITLE
fix pytest warning about unknown markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    flake8: marks tests checking for flake8 compliance
+    linter: marks tests as linter checks


### PR DESCRIPTION
The package doesn't depend on `ament_flake8` / `ament_lint` so these markers aren't defined. Since we still want to use them to select subset of tests and don't want to add a dependency for it this patch simply declares them for `pytest`.