### PR TITLE
add quotes around ament_python_executable variable in local_setup.bat

### DIFF
--- a/ament_package/template/isolated_prefix_level/local_setup.bat.in
+++ b/ament_package/template/isolated_prefix_level/local_setup.bat.in
@@ -29,12 +29,12 @@ goto:eof
   if "%AMENT_PYTHON_EXECUTABLE%" NEQ "" (
     set "_ament_python_executable=%AMENT_PYTHON_EXECUTABLE%"
   )
-  if NOT exist %_ament_python_executable% (
+  if NOT exist "%_ament_python_executable%" (
     for %%I in (python.exe) do (
       if "%%~$PATH:I" NEQ "" set "_ament_python_executable=%%~$PATH:I"
     )
   )
-  if NOT exist %_ament_python_executable% (
+  if NOT exist "%_ament_python_executable%" (
     echo "Could not find Python executable: either add the folder of the Python executable (e.g. installed with Chocolatey) to the PATH variable or explicitly set the environment variable AMENT_PYTHON_EXECUTABLE to the full path of the Python executable"
     goto:eof
   )

--- a/ament_package/template/prefix_level/local_setup.bat.in
+++ b/ament_package/template/prefix_level/local_setup.bat.in
@@ -30,6 +30,8 @@ goto:eof
   )
 
   set "ordered_packages="
+  :: escape potential closing parenthesis which would break the for loop
+  set "ament_python_executable=%ament_python_executable:)=^)%"
   for /f %%p in ('""%ament_python_executable%" "%~dp0_order_packages.py" "%~2\""') do (
     if "!ordered_packages!" NEQ "" set "ordered_packages=!ordered_packages!;"
     set "ordered_packages=!ordered_packages!%%p"


### PR DESCRIPTION
Fixes (update: no it doesn't) #84.