### PR TITLE
if no package.dsv is available fallback to a local_setup file

### DIFF
--- a/ament_package/template/prefix_level/_local_setup_util.py
+++ b/ament_package/template/prefix_level/_local_setup_util.py
@@ -193,6 +193,7 @@ def get_commands(pkg_name, prefix, primary_extension, additional_extension):
                     FORMAT_STR_INVOKE_SCRIPT.format_map({
                         'prefix': prefix,
                         'script_path': package_ext_path})]
+                break
 
     return commands
 

--- a/ament_package/template/prefix_level/_local_setup_util.py
+++ b/ament_package/template/prefix_level/_local_setup_util.py
@@ -182,6 +182,18 @@ def get_commands(pkg_name, prefix, primary_extension, additional_extension):
     if os.path.exists(package_dsv_path):
         commands += process_dsv_file(
             package_dsv_path, prefix, primary_extension, additional_extension)
+    else:
+        for ext in (
+            [additional_extension] if additional_extension else []
+        ) + [primary_extension]:
+            package_ext_path = os.path.join(
+                prefix, 'share', pkg_name, 'local_setup.' + ext)
+            if os.path.exists(package_ext_path):
+                commands += [
+                    FORMAT_STR_INVOKE_SCRIPT.format_map({
+                        'prefix': prefix,
+                        'script_path': package_ext_path})]
+
     return commands
 
 


### PR DESCRIPTION
Follow up of #89. This will hopefully unbreak the binary jobs and "fix" the environment setup. It won't achieve the performance improvement though until the `package.dsv` files are generated in Debian packages.