### PR TITLE
fix reading the package run dependencies

### DIFF
--- a/ament_package/template/prefix_level/_local_setup_util.py
+++ b/ament_package/template/prefix_level/_local_setup_util.py
@@ -111,7 +111,7 @@ def add_package_runtime_dependencies(path, packages):
     marker_file = path.parents[1] / 'package_run_dependencies' / path.name
     if marker_file.exists():
         content = marker_file.read_text()
-        dependencies = set(content.split(os.pathsep) if content else [])
+        dependencies = set(content.split(';') if content else [])
     packages[marker_file.name] = dependencies
 
 


### PR DESCRIPTION
Follow up of #89. Fixes reading the run dependencies which always use a semicolon / CMake list separator - independent of the platform