### PR TITLE
Fix sh command to remove trailing separator

### DIFF
--- a/ament_package/template/prefix_level/_local_setup_util.py
+++ b/ament_package/template/prefix_level/_local_setup_util.py
@@ -46,8 +46,8 @@ def main(argv=sys.argv[1:]):  # noqa: D103
         FORMAT_STR_USE_ENV_VAR = '${name}'
         FORMAT_STR_INVOKE_SCRIPT = 'AMENT_CURRENT_PREFIX="{prefix}" ' \
             '_ament_prefix_sh_source_script "{script_path}"'
-        FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if test "$(echo -n ${name} | ' \
-            'tail -c 1)" = ":" ; then; export {name}=${{{name}%?}} ; fi'
+        FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if [ "$(echo -n ${name} | ' \
+            'tail -c 1)" = ":" ]; then export {name}=${{{name}%?}} ; fi'
     elif args.primary_extension == 'bat':
         FORMAT_STR_COMMENT_LINE = ':: {comment}'
         FORMAT_STR_SET_ENV_VAR = 'set "{name}={value}"'


### PR DESCRIPTION
Remove tailing semi-colon from "then;"
Also replace test command with "[" for clarity.

Introduced in #104.

Related colcon fix: https://github.com/colcon/colcon-core/pull/261