### PR TITLE
fix performance regression in environment setup

### DIFF
--- a/ament_package/template/prefix_level/_local_setup_util.py
+++ b/ament_package/template/prefix_level/_local_setup_util.py
@@ -73,8 +73,9 @@ def main(argv=sys.argv[1:]):  # noqa: D103
             args.additional_extension
         ):
             print(line)
-        for line in _remove_trailing_separators():
-            print(line)
+
+    for line in _remove_trailing_separators():
+        print(line)
 
 
 def get_packages(prefix_path):


### PR DESCRIPTION
The trailing semicolon cleanup added in #104 was performed after every package. It only needs to happen once after all packages have finished.