### PR TITLE
skip empty lines in dsv files

### DIFF
--- a/ament_package/template/prefix_level/_local_setup_util.py
+++ b/ament_package/template/prefix_level/_local_setup_util.py
@@ -221,6 +221,9 @@ def process_dsv_file(
 
     basenames = OrderedDict()
     for line in lines:
+        # skip over empty or whitespace-only lines
+        if not line.strip():
+            continue
         type_, remainder = line.split(';', 1)
         if type_ != DSV_TYPE_SOURCE:
             # handle non-source lines


### PR DESCRIPTION
Which allows to group multiple lines if a `dsv` file updates more than one environment variable.

Same as colcon/colcon-core#275.