### PR TITLE
Extend library path to have multiarch directory

### DIFF
--- a/ament_package/template/environment_hook/library_path.sh
+++ b/ament_package/template/environment_hook/library_path.sh
@@ -8,9 +8,15 @@ if [ "$_UNAME" = "Darwin" ]; then
 fi
 unset _UNAME
 
+# Collect machine architecture triplet for libraries using GNU install dirs
+_MULTIARCH_TRIPLET=`gcc -dumpmachine OUTPUT_VARIABLE MULTIARCH_TRIPLET OUTPUT_STRIP_TRAILING_WHITESPACE`
+
 if [ $_IS_DARWIN -eq 0 ]; then
   ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"
+  ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib/$MULTIARCH_TRIPLET"
 else
   ament_prepend_unique_value DYLD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"
+  ament_prepend_unique_value DYLD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib/$MULTIARCH_TRIPLET"
 fi
+unset _MULTIARCH_TRIPLET
 unset _IS_DARWIN


### PR DESCRIPTION
This fixes issues finding libraries installed by external packages using GNUInstallDirs.
For example, CycloneDDS, see: https://github.com/ros2/rmw_cyclonedds/issues/182

Prior to ROS Bouncy, we were extending the library path to handle this case: https://github.com/ros2/ros_workspace/pull/2

The patch was removed for Ubuntu Bionic, as it was deemed unnecessary due to a change upstream: https://github.com/ros2/ros_workspace/pull/10

---

I'm not actually sure if this will fix the referenced issue (or how to test it for that matter).