### PR TITLE
Declare missing dependency on python3-importlib-resources

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
   <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <depend>python3-importlib-metadata</depend>
+  <depend>python3-importlib-resources</depend>
   <depend>python3-setuptools</depend>
 
   <test_depend>python3-flake8</test_depend>


### PR DESCRIPTION
Requires ros/rosdistro#28001.

Used here:
https://github.com/ament/ament_package/blob/65e3322c5c668684dc973025bebbc70c6a77592f/ament_package/templates.py#L18-L21

The source code supports using the `importlib_resources` package, but on all of the platforms we're running regular builds for, we have Python 3.7, which provides the package as part of Python itself.