### PR TITLE
Support Python 3.8-provided importlib.metadata

### DIFF
--- a/ament_package/__init__.py
+++ b/ament_package/__init__.py
@@ -16,7 +16,10 @@
 
 # set version number
 try:
-    import importlib_metadata
+    try:
+        import importlib.metadata as importlib_metadata
+    except ModuleNotFoundError:
+        import importlib_metadata
     try:
         __version__ = importlib_metadata.version('ament_package')
     except importlib_metadata.PackageNotFoundError:


### PR DESCRIPTION
The `importlib_metadata` package is a backport of the `importlib.metadata` module from Python 3.8. Fedora (and possibly others) no longer package `importlib_metadata` because they ship Python versions which have the functionality built-in.