### PR TITLE
Make python executable variable ament_package specific

### DIFF
--- a/ament_package/template/prefix_level/local_setup.bat.in
+++ b/ament_package/template/prefix_level/local_setup.bat.in
@@ -20,7 +20,7 @@ goto:eof
     set "_ament_python_executable=%AMENT_PYTHON_EXECUTABLE%"
   ) else (
     :: use the Python executable known at configure time
-    set "_ament_python_executable=@PYTHON_EXECUTABLE@"
+    set "_ament_python_executable=@ament_package_PYTHON_EXECUTABLE@"
     :: if it doesn't exist try a fall back
     if not exist "!_ament_python_executable!" (
       python --version > NUL 2> NUL

--- a/ament_package/template/prefix_level/local_setup.sh.in
+++ b/ament_package/template/prefix_level/local_setup.sh.in
@@ -18,7 +18,7 @@ fi
 : ${AMENT_SHELL:=sh}
 
 # use the Python executable known at configure time
-_ament_python_executable="@PYTHON_EXECUTABLE@"
+_ament_python_executable="@ament_package_PYTHON_EXECUTABLE@"
 # allow overriding it with a custom location
 if [ -n "$AMENT_PYTHON_EXECUTABLE" ]; then
   _ament_python_executable="$AMENT_PYTHON_EXECUTABLE"


### PR DESCRIPTION
Part of https://github.com/ament/ament_cmake/pull/355, and should be merged with it. I think this is the minimum to get the prefix_level scripts working with `FindPython3`.