### PR TITLE
Add support for comment lines in dsv files

### DIFF
--- a/ament_package/template/prefix_level/_local_setup_util.py
+++ b/ament_package/template/prefix_level/_local_setup_util.py
@@ -232,6 +232,9 @@ def process_dsv_file(
         # skip over empty or whitespace-only lines
         if not line.strip():
             continue
+        # skip over comments
+        if line.startswith('#'):
+            continue
         try:
             type_, remainder = line.split(';', 1)
         except ValueError:


### PR DESCRIPTION
Paris with colcon/colcon-core#550

This is a pretty containable change, and should be considered for backport to supported distros.