### PR TITLE
Add setuptools dependency back in.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,8 @@
   <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
+  <buildtool_export_depend>python3-setuptools</buildtool_export_depend>
+
   <exec_depend>python3-importlib-metadata</exec_depend>
   <exec_depend>python3-importlib-resources</exec_depend>
 


### PR DESCRIPTION
It turns out that non-ament_python packages (like most ament packages) were taking an implicit dependency on setuptools via this package.  When we removed this in commit
832558105e49bea21351d0c1640926a6eb86bf5e, we removed that implicit dependency and hence broke the packages.

The correct long-term solution here is probably to make those packages explicitly depend on setuptools.  But for a short-term fix, we can restore the dependency here as a buildtool_export_depend.