### PR TITLE
Always consider .dsv files, even when no shell specific script exists

### DIFF
--- a/ament_package/template/prefix_level/_local_setup_util.py
+++ b/ament_package/template/prefix_level/_local_setup_util.py
@@ -252,11 +252,11 @@ def process_dsv_file(
         else:
             # group remaining source lines by basename
             path_without_ext, ext = os.path.splitext(remainder)
+            if path_without_ext not in basenames:
+                basenames[path_without_ext] = set()
             assert ext.startswith('.')
             ext = ext[1:]
             if ext in (primary_extension, additional_extension):
-                if path_without_ext not in basenames:
-                    basenames[path_without_ext] = set()
                 basenames[path_without_ext].add(ext)
 
     # add the dsv extension to each basename if the file exists


### PR DESCRIPTION
Fix #145 

Copy of https://github.com/colcon/colcon-core/pull/244/commits/3697164b248d578ec15e9f0d369d005cf1d9894a