### PR TITLE
Simplify removing leading and trailing separators

### DIFF
--- a/ament_package/template/prefix_level/_local_setup_util.py
+++ b/ament_package/template/prefix_level/_local_setup_util.py
@@ -48,10 +48,8 @@ def main(argv=sys.argv[1:]):  # noqa: D103
         FORMAT_STR_USE_ENV_VAR = '${name}'
         FORMAT_STR_INVOKE_SCRIPT = 'AMENT_CURRENT_PREFIX="{prefix}" ' \
             '_ament_prefix_sh_source_script "{script_path}"'
-        FORMAT_STR_REMOVE_LEADING_SEPARATOR = 'if [ "$(echo -n ${name} | ' \
-            'head -c 1)" = ":" ]; then export {name}=${{{name}#?}} ; fi'
-        FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if [ "$(echo -n ${name} | ' \
-            'tail -c 1)" = ":" ]; then export {name}=${{{name}%?}} ; fi'
+        FORMAT_STR_REMOVE_LEADING_SEPARATOR = 'export {name}=${{{name}#:}}'
+        FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'export {name}=${{{name}%:}}'
     elif args.primary_extension == 'bat':
         FORMAT_STR_COMMENT_LINE = ':: {comment}'
         FORMAT_STR_SET_ENV_VAR = 'set "{name}={value}"'


### PR DESCRIPTION
Previously, we checked if the leading or trailing character was a colon and then used a wildcard to remove it.  It is simpler to just remove a leading or trailing colon. This has the added benefit of only using shell built-in functions.

This was discovered when trying to source /opt/ros/humble/setup.sh on a Linux system with busybox.  The ROS environment failed to initialize because busybox was not built with support for '-c" in head by default.  Making this change allowed both bash and ash to source the environment without needing GNU coreutils or changes to busybox to enable the '-c" option in tail or head.